### PR TITLE
add config option to shorten displayed urls automatically and set a t…

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,6 +27,8 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('linkclass')->defaultValue('')->end()
                 ->scalarNode('target')->defaultValue('_blank')->end()
                 ->scalarNode('debugmode')->defaultFalse()->end()
+                ->scalarNode('shortenUrl')->defaultFalse()->end()
+                ->scalarNode('shortenUrlThreshold')->defaultValue(25)->end()
             ->end();
 
         return $treeBuilder;

--- a/Extension/UrlAutoConverterTwigExtension.php
+++ b/Extension/UrlAutoConverterTwigExtension.php
@@ -8,6 +8,8 @@ class UrlAutoConverterTwigExtension extends \Twig_Extension
     protected $target;
     protected $debugMode;
     protected $debugColor = '#00ff00';
+    protected $shortenUrl;
+    protected $shortenUrlThreshold;
 
     // @codeCoverageIgnoreStart
 
@@ -34,6 +36,16 @@ class UrlAutoConverterTwigExtension extends \Twig_Extension
     public function setDebugColor($color)
     {
         $this->debugColor = $color;
+    }
+
+    public function setShortenUrl($shortenUrl)
+    {
+        $this->shortenUrl = $shortenUrl;
+    }
+
+    public function setShortenUrlThreshold($shortenUrlThreshold)
+    {
+        $this->shortenUrlThreshold = $shortenUrlThreshold;
     }
 
     // @codeCoverageIgnoreEnd
@@ -94,6 +106,17 @@ class UrlAutoConverterTwigExtension extends \Twig_Extension
             $punctuation = $matches[2];
         } else {
             $punctuation = '';
+        }
+
+        // shorten link if option is set
+        if ($this->shortenUrl && filter_var($url, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED)) {
+            $url = preg_replace('/^(https{0,1}:\/\/|mailto:)(.+)$/', '$2', $urlWithPrefix); // remove schema
+            if (strpos($url, '@') === false && strlen($url) > $this->shortenUrlThreshold) {
+                $parts = explode('/', rtrim($url, '/'));
+                if (count($parts) > 2) {
+                    $url = array_shift($parts) . '/.../' . array_pop($parts);
+                }
+            }
         }
 
         return '<a href="'.$urlWithPrefix.'" class="'.$this->linkClass.'" target="'.$this->target.'"'.$style.'>'.$url.'</a>'.$punctuation;

--- a/README.md
+++ b/README.md
@@ -41,11 +41,15 @@ The supported options for the LiipUrlAutoConverterBundle are: (put in /app/confi
         linkclass:
         target: _blank
         debugmode: false
+        shortenUrl: false
+        shortenUrlThreshold: 25
 
 
-- "linkClass":  css class that will be added automatically to converted links. default: "" (empty)
-- "target":     browser link target. default: "_blank"
-- "debugMode":  if true, links will be colored with a nasty green color - cool for testing. default: false
+- "linkClass":           css class that will be added automatically to converted links. default: "" (empty)
+- "target":              browser link target. default: "_blank"
+- "debugMode":           if true, links will be colored with a nasty green color - cool for testing. default: false
+- "shortenUrl":          if true, links will be shorten automatically. default: false
+- "shortenUrlThreshold": only shorten urls that are longer than the threshold. default: 25
 
 All settings are optional.
 

--- a/Resources/config/urlautoconverter.xml
+++ b/Resources/config/urlautoconverter.xml
@@ -16,6 +16,12 @@
             <call method="setDebugMode">
                 <argument>%liip_url_auto_converter.debugmode%</argument>
             </call>
+            <call method="setShortenUrl">
+                <argument>%liip_url_auto_converter.shortenUrl%</argument>
+            </call>
+            <call method="setShortenUrlThreshold">
+                <argument>%liip_url_auto_converter.shortenUrlThreshold%</argument>
+            </call>
         </service>
     </services>
 

--- a/Tests/DependencyInjection/LiipUrlAutoConverterExtensionTest.php
+++ b/Tests/DependencyInjection/LiipUrlAutoConverterExtensionTest.php
@@ -18,6 +18,8 @@ class LiipUrlAutoConverterExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertParameter('', 'liip_url_auto_converter.linkclass');
         $this->assertParameter('_blank', 'liip_url_auto_converter.target');
         $this->assertParameter(false, 'liip_url_auto_converter.debugmode');
+        $this->assertParameter(false, 'liip_url_auto_converter.shortenUrl');
+        $this->assertParameter(25, 'liip_url_auto_converter.shortenUrlThreshold');
         $this->assertHasDefinition('liip_url_auto_converter.twig.extension');
     }
 
@@ -25,11 +27,13 @@ class LiipUrlAutoConverterExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->configuration = new ContainerBuilder();
         $loader = new LiipUrlAutoConverterExtension();
-        $loader->load(array(array('linkclass' => 'foo', 'target' => 'bar', 'debugmode' => true)), $this->configuration);
+        $loader->load(array(array('linkclass' => 'foo', 'target' => 'bar', 'debugmode' => true, 'shortenUrl' => true, 'shortenUrlThreshold' => 20)), $this->configuration);
 
         $this->assertParameter('foo', 'liip_url_auto_converter.linkclass');
         $this->assertParameter('bar', 'liip_url_auto_converter.target');
         $this->assertParameter(true, 'liip_url_auto_converter.debugmode');
+        $this->assertParameter(true, 'liip_url_auto_converter.shortenUrl');
+        $this->assertParameter(20, 'liip_url_auto_converter.shortenUrlThreshold');
         $this->assertHasDefinition('liip_url_auto_converter.twig.extension');
     }
 


### PR DESCRIPTION
Add the option to have a url shortened automatically if it exceeds a certain threshold in length.

Feature: Yes
BC: No

Example:
Before: `https://foo.bar/foo/bar/baz/some_really_long_url-foobar.html` would give you: `<a class="" href="https://foo.bar/foo/bar/baz/some_really_long_url-foobar.html" target="_blank">https://foo.bar/foo/bar/baz/some_really_long_url-foobar.html</a>`
Now: `https://foo.bar/foo/bar/baz/some_really_long_url-foobar.html` would give you: `<a class="" href="https://foo.bar/foo/bar/baz/some_really_long_url-foobar.html" target="_blank">foo.bar/.../some_really_long_url-foobar.html</a>`

It can now automatically remove the schema and only show the domain as well as the last part of the url.

Note: E-Mail Links are not affected